### PR TITLE
add runtime=java for java apps

### DIFF
--- a/docs/02_lab_migrate/0205.md
+++ b/docs/02_lab_migrate/0205.md
@@ -18,10 +18,11 @@ Make sure the api-gateway and admin-server microservices have public IP addresse
 
 ## Step by step guidance
    
-1. From the Git Bash window, set a `VERSION` environment variable to the version number that you also find in the `pom.xml` file, `3.0.2`.
+1. From the Git Bash window, set a `VERSION` environment variable to the version number that you also find in the `pom.xml` file.
 
    ```bash
-   VERSION=3.0.2
+   VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+   echo $VERSION
    ```
 
 1. You will start by building all the microservice of the spring petclinic application. To accomplish this, run `mvn clean package` in the root directory of the application.
@@ -33,7 +34,7 @@ Make sure the api-gateway and admin-server microservices have public IP addresse
 
 1. Once your build has finished, you can create each of the microservices. You'll start with the `api-gateway`. Since this is the entrypoint to your other microservices, you will create it with an `external` ingress. Also, you will bind this app to the configserver and eureka components you created earlier.
 
-   ```bash    
+   ```bash
    APP_NAME=api-gateway
 
    az containerapp create \
@@ -44,12 +45,13 @@ Make sure the api-gateway and admin-server microservices have public IP addresse
       --environment $ACA_ENVIRONMENT \
       --min-replicas 1 \
       --artifact ./spring-petclinic-api-gateway/target/spring-petclinic-api-gateway-$VERSION.jar \
-      --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME
+      --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME \
+      --runtime java
    ```
 
 1. Wait for the provisioning of this first service to finish, and then create the next microservice. This will be the `admin-server`, which is similar in settings to the `api-gateway`. 
 
-   ```bash    
+   ```bash
    APP_NAME=admin-server
    az containerapp create \
       --name $APP_NAME \
@@ -59,12 +61,13 @@ Make sure the api-gateway and admin-server microservices have public IP addresse
       --environment $ACA_ENVIRONMENT \
       --min-replicas 1 \
       --artifact ./spring-petclinic-admin-server/target/spring-petclinic-admin-server-$VERSION.jar \
-      --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME
+      --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME \
+      --runtime java
    ```
 
 1. Wait for the provisioning to finish, now you can create the other microservices, `customers`, `vets` and `visits`. These will be internal microservices, exposed by the `api-gateway`. Since these microservices connect to the MySQL database, you will also assign them the user assigned managed identity.
 
-   ```bash    
+   ```bash
    APP_NAME=customers-service
    az containerapp create \
       --name $APP_NAME \
@@ -74,7 +77,8 @@ Make sure the api-gateway and admin-server microservices have public IP addresse
       --environment $ACA_ENVIRONMENT \
       --min-replicas 1 \
       --artifact ./spring-petclinic-customers-service/target/spring-petclinic-customers-service-$VERSION.jar \
-      --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME
+      --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME \
+      --runtime java
 
    APP_NAME=vets-service
    az containerapp create \
@@ -85,17 +89,18 @@ Make sure the api-gateway and admin-server microservices have public IP addresse
       --environment $ACA_ENVIRONMENT \
       --min-replicas 1 \
       --artifact ./spring-petclinic-vets-service/target/spring-petclinic-vets-service-$VERSION.jar \
-      --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME
+      --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME \
+      --runtime java
 
    APP_NAME=visits-service
    az containerapp create \
-     --name $APP_NAME \
-     --resource-group $RESOURCE_GROUP \
-     --ingress internal \
-     --target-port 8080 \
-     --environment $ACA_ENVIRONMENT \
-     --min-replicas 1 \
-     --artifact ./spring-petclinic-visits-service/target/spring-petclinic-visits-service-$VERSION.jar \
-     --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME
+      --name $APP_NAME \
+      --resource-group $RESOURCE_GROUP \
+      --ingress internal \
+      --target-port 8080 \
+      --environment $ACA_ENVIRONMENT \
+      --min-replicas 1 \
+      --artifact ./spring-petclinic-visits-service/target/spring-petclinic-visits-service-$VERSION.jar \
+      --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME \
+      --runtime java
    ```
-   

--- a/docs/03_lab_monitor/0303.md
+++ b/docs/03_lab_monitor/0303.md
@@ -71,7 +71,7 @@ You can follow the below guidance to do so.
    echo $SP_ID
    ```
 
-1. Assign user identity to container apps environment
+1. Assign the user identity to the container apps environment
 
    ```bash
    az containerapp env identity assign -g $RESOURCE_GROUP -n $ACA_ENVIRONMENT --user-assigned $USER_ID

--- a/docs/03_lab_monitor/0303.md
+++ b/docs/03_lab_monitor/0303.md
@@ -43,9 +43,8 @@ You can follow the below guidance to do so.
 1. Make note of the Application Insights connection string, you will need this later in this module.
 
    ```bash
-   AI_CONNECTIONSTRING=$(az monitor app-insights component show --app $AINAME -g $RESOURCE_GROUP --query connectionString)
-   
-   AI_CONNECTIONSTRING="${AI_CONNECTIONSTRING//\"/}"
+   AI_CONNECTIONSTRING=$(az monitor app-insights component show --app $AINAME -g $RESOURCE_GROUP --query connectionString --output tsv)
+
    echo $AI_CONNECTIONSTRING
    ```
 
@@ -74,7 +73,7 @@ You can follow the below guidance to do so.
 
 1. Assign access for the container app identity to pull images from your container registry.
 
-   ```
+   ```bash
    ACR_ID=$(az acr show -n $MYACR -g $RESOURCE_GROUP --query id -o tsv)
    az role assignment create --assignee $SP_ID --scope $ACR_ID --role acrpull
    ```
@@ -89,14 +88,14 @@ You can follow the below guidance to do so.
 1. In this new folder download the latest application insights agent jar file. Also rename the jar file to ai.jar so you have an easier name in the next steps.
 
    ```bash
-   wget https://github.com/microsoft/ApplicationInsights-Java/releases/download/3.4.12/applicationinsights-agent-3.4.12.jar
-   cp applicationinsights-agent-3.4.12.jar ai.jar
-   rm applicationinsights-agent-3.4.12.jar
+   AI_VERSION=3.5.4
+   wget https://github.com/microsoft/ApplicationInsights-Java/releases/download/$AI_VERSION/applicationinsights-agent-$AI_VERSION.jar
+   mv applicationinsights-agent-$AI_VERSION.jar ai.jar
    ```
 
-1. Create the below `Dockerfile` in the `staging-acr` directory. This `Dockerfile` copies the application jar file and `ai.jar` file into the container. It also adds the `ai.jar` file as a javaagent to your app, so it can start logging. The resulting `Dockerfile` should look like this.
-   
-   ```bash
+1. Create the below `Dockerfile` in the `staging-acr` directory. This `Dockerfile` copies the application jar file and `ai.jar` file into the container. It also adds the `ai.jar` file as a javaagent to your app, so it can start logging. You should replace the value `3.0.2` with the VERSION you get from source project. The resulting `Dockerfile` should look like this.
+
+   ```text
    # Build stage
    FROM mcr.microsoft.com/openjdk/jdk:17-mariner
    COPY spring-petclinic-my-service-3.0.2.jar app.jar
@@ -128,7 +127,8 @@ You can follow the below guidance to do so.
       --ingress external \
       --target-port 8080 \
       --min-replicas 1 \
-      --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME
+      --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME \
+      --runtime java
 
    sed -i "s|$APP_NAME|my-service|g" Dockerfile
    rm spring-petclinic-$APP_NAME-$VERSION.jar
@@ -155,7 +155,8 @@ You can follow the below guidance to do so.
       --ingress internal \
       --target-port 8080 \
       --min-replicas 1 \
-      --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME
+      --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME \
+      --runtime jaa
 
    sed -i "s|$APP_NAME|my-service|g" Dockerfile
    rm spring-petclinic-$APP_NAME-$VERSION.jar
@@ -178,7 +179,8 @@ You can follow the below guidance to do so.
       --ingress internal \
       --target-port 8080 \
       --min-replicas 1 \
-      --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME
+      --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME \
+      --runtime java
 
    sed -i "s|$APP_NAME|my-service|g" Dockerfile
    rm spring-petclinic-$APP_NAME-$VERSION.jar
@@ -201,7 +203,8 @@ You can follow the below guidance to do so.
       --ingress internal \
       --target-port 8080 \
       --min-replicas 1 \
-      --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME
+      --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME \
+      --runtime java
 
    sed -i "s|$APP_NAME|my-service|g" Dockerfile
    rm spring-petclinic-$APP_NAME-$VERSION.jar
@@ -224,7 +227,8 @@ You can follow the below guidance to do so.
       --ingress external \
       --target-port 8080 \
       --min-replicas 1 \
-      --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME
+      --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME \
+      --runtime java
 
    sed -i "s|$APP_NAME|my-service|g" Dockerfile
    rm spring-petclinic-$APP_NAME-$VERSION.jar

--- a/docs/03_lab_monitor/0303.md
+++ b/docs/03_lab_monitor/0303.md
@@ -60,7 +60,7 @@ You can follow the below guidance to do so.
        --admin-enabled true
    ```
 
-1. You will also need to create an identity which can be used by your container apps to connect to the Container Registry. 
+1. You will also need to create an identity which can be used by your container apps to connect to the Container Registry.
   
    ```bash
    ACA_IDENTITY=uid-petclinic-$UNIQUEID
@@ -69,6 +69,12 @@ You can follow the below guidance to do so.
    SP_ID=$(az identity show --resource-group $RESOURCE_GROUP --name $ACA_IDENTITY --query principalId --output tsv)
    echo $USER_ID
    echo $SP_ID
+   ```
+
+1. Assign user identity to container apps environment
+
+   ```bash
+   az containerapp env identity assign -g $RESOURCE_GROUP -n $ACA_ENVIRONMENT --user-assigned $USER_ID
    ```
 
 1. Assign access for the container app identity to pull images from your container registry.

--- a/docs/05_lab_security/0504.md
+++ b/docs/05_lab_security/0504.md
@@ -14,7 +14,7 @@ For making use of internal networking and getting a private inbound IP address f
 ## Step by step guidance
 
 1. Delete your existing container apps and Azure Container Apps environment as we will be recreating these resources. You will also need to delete the builder service of your Azure Container Apps environment. 
-    
+
    ```bash
    az containerapp delete -g $RESOURCE_GROUP -n api-gateway -y
    az containerapp delete -g $RESOURCE_GROUP -n admin-server -y
@@ -27,7 +27,7 @@ For making use of internal networking and getting a private inbound IP address f
 
    az containerapp env delete -n $ACA_ENVIRONMENT -g $RESOURCE_GROUP -y
    ```
-   
+
 1. Create a new Azure Container Apps environment into the container apps subnet and make it internal-only.
 
    ```bash
@@ -72,6 +72,12 @@ For making use of internal networking and getting a private inbound IP address f
       --environment $ACA_ENVIRONMENT \
       --resource-group $RESOURCE_GROUP \
       --name $JAVA_EUREKA_COMP_NAME
+   ```
+
+1. Assign user identity to container apps environment
+
+   ```bash
+   az containerapp env identity assign -g $RESOURCE_GROUP -n $ACA_ENVIRONMENT --user-assigned $USER_ID
    ```
 
 1. Recreate and rebuild all of the containers, using the docker file and push them to your Azure Container Registry. This will create the apps in your Azure Container Apps environment, build their images and pull each image to each of the apps. These images will include the Application Insights jar file for application monitoring. Run the commands from your staging-acr folder.
@@ -190,7 +196,6 @@ For making use of internal networking and getting a private inbound IP address f
    rm spring-petclinic-$APP_NAME-$VERSION.jar
    ```
 
-   
 1. You will also need to recreate the service connections from each of the `customers-service`, `visits-service` and `vets-service` services to the database. For this, you need the resource ID of each of the apps:
 
    ```bash
@@ -293,7 +298,7 @@ For making use of internal networking and getting a private inbound IP address f
    ```
    
 1. Link this private dns zone to your virtual network
- 
+
    ```bash
    az network private-dns link vnet create \
       --resource-group $RESOURCE_GROUP \
@@ -303,7 +308,7 @@ For making use of internal networking and getting a private inbound IP address f
    ```
 
 1. Create a dns record for the private IP address of your Container Apps environment.
-   
+
    ```bash
    staticIP=$(az containerapp env show \
      --name $ACA_ENVIRONMENT \

--- a/docs/05_lab_security/0504.md
+++ b/docs/05_lab_security/0504.md
@@ -94,6 +94,7 @@ For making use of internal networking and getting a private inbound IP address f
       --user-assigned $USER_ID \
       --min-replicas 1 \
       --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME \
+      --runtime java \
       --registry-server $MYACR.azurecr.io \
       --registry-identity $USER_ID
 
@@ -113,6 +114,7 @@ For making use of internal networking and getting a private inbound IP address f
       --user-assigned $USER_ID \
       --min-replicas 1 \
       --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME \
+      --runtime java \
       --ingress internal \
       --target-port 8080 \
       --registry-server $MYACR.azurecr.io \
@@ -134,6 +136,7 @@ For making use of internal networking and getting a private inbound IP address f
       --user-assigned $USER_ID \
       --min-replicas 1 \
       --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME \
+      --runtime java \
       --ingress internal \
       --target-port 8080 \
       --registry-server $MYACR.azurecr.io \
@@ -156,6 +159,7 @@ For making use of internal networking and getting a private inbound IP address f
       --min-replicas 1 \
       --cpu 2 --memory 4Gi \
       --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME \
+      --runtime java \
       --ingress internal \
       --target-port 8080 \
       --registry-server $MYACR.azurecr.io \
@@ -178,6 +182,7 @@ For making use of internal networking and getting a private inbound IP address f
       --environment $ACA_ENVIRONMENT \
       --min-replicas 1 \
       --bind $JAVA_CONFIG_COMP_NAME $JAVA_EUREKA_COMP_NAME \
+      --runtime java \
       --registry-server $MYACR.azurecr.io \
       --registry-identity $USER_ID
 

--- a/docs/variables.txt
+++ b/docs/variables.txt
@@ -36,17 +36,9 @@ WORKSPACEKEY=$(az monitor log-analytics workspace get-shared-keys -n $WORKSPACE 
 WORKSPACEID=$(az monitor log-analytics workspace show -n $WORKSPACE -g $RESOURCE_GROUP --query id -o tsv)
 AINAME=ai-$APPNAME-$UNIQUEID
 
-AI_CONNECTIONSTRING=$(az monitor app-insights component show --app $AINAME -g $RESOURCE_GROUP --query connectionString)
+AI_CONNECTIONSTRING=$(az monitor app-insights component show --app $AINAME -g $RESOURCE_GROUP --query connectionString -o tsv)
 
+appgw=$(az network application-gateway show -g $RESOURCE_GROUP -n $APPGW_NAME)
 
-      AI_CONNECTIONSTRING="${AI_CONNECTIONSTRING//\"/}"
-   echo $AI_CONNECTIONSTRING
-
-
-  
-
-    appgw=$(az network application-gateway show -g $RESOURCE_GROUP -n $APPGW_NAME)
-
-
-    KEYVAULT_NAME=kv-petclinic-b6eff4
+KEYVAULT_NAME=kv-$APPNAME-$UNIQUEID
 


### PR DESCRIPTION
## Purpose

* Add parameter `--runtime java` to java apps
* Assign MI to container env before used in container apps
* Upgrade Application Insights to 3.5.4
* some minor refines on doc

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->