### PR TITLE
chat agent use same online MySQL database as other components

### DIFF
--- a/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/ChatAgentApplication.java
+++ b/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/ChatAgentApplication.java
@@ -2,7 +2,9 @@ package org.springframework.samples.petclinic.agent;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ImportRuntimeHints;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 @ImportRuntimeHints(PetClinicRuntimeHints.class)
@@ -12,4 +14,8 @@ public class ChatAgentApplication {
 		SpringApplication.run(ChatAgentApplication.class, args);
 	}
 
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
 }

--- a/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/chat/AgentConfig.java
+++ b/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/chat/AgentConfig.java
@@ -5,6 +5,7 @@ import com.azure.ai.openai.OpenAIClientBuilder;
 import com.azure.identity.DefaultAzureCredentialBuilder;
 import org.springframework.ai.azure.openai.AzureOpenAiChatModel;
 import org.springframework.ai.azure.openai.AzureOpenAiChatOptions;
+import org.springframework.ai.azure.openai.AzureOpenAiResponseFormat;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.ChatClientCustomizer;
 import org.springframework.ai.chat.client.advisor.PromptChatMemoryAdvisor;
@@ -49,6 +50,7 @@ public class AgentConfig {
 		var openAIChatOptions = AzureOpenAiChatOptions.builder()
 			.withDeploymentName(properties.getDeploymentName())
 			.withTemperature(properties.getTemperature())
+            .withResponseFormat(AzureOpenAiResponseFormat.TEXT)
 			.build();
 
 		// provide Context to load function callbacks

--- a/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/chat/ChatOptionsProperties.java
+++ b/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/chat/ChatOptionsProperties.java
@@ -7,7 +7,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Getter
 @Setter
 @ConfigurationProperties(prefix = ChatOptionsProperties.PREFIX)
-class ChatOptionsProperties {
+public class ChatOptionsProperties {
 
     static final String PREFIX = "spring.ai.azure.openai.chat.options";
 

--- a/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/chat/OwnerTools.java
+++ b/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/chat/OwnerTools.java
@@ -7,10 +7,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Description;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.samples.petclinic.agent.owner.Owner;
-import org.springframework.samples.petclinic.agent.owner.OwnerRepository;
+import org.springframework.samples.petclinic.agent.dto.OwnerDto;
+import org.springframework.samples.petclinic.agent.service.OwnerService;
 
 import java.util.List;
 import java.util.function.Function;
@@ -18,43 +16,42 @@ import java.util.function.Function;
 @Configuration
 public class OwnerTools {
 
-	private final OwnerRepository owners;
+	private final OwnerService ownerService;
 
-	public OwnerTools(OwnerRepository ownerRepository) {
-		this.owners = ownerRepository;
+	public OwnerTools(OwnerService ownerService) {
+		this.ownerService = ownerService;
 	}
 
 	@Bean
 	@Description("Query the owners by last name, the owner information include owner id, address, telephone, city, first name and last name"
 			+ "\n The owner also include the pets information, include the pet name, pet type and birth"
 			+ "\n The pet include serveral visit record, include the visit name and visit date")
-	public Function<OwnerQueryRequest, List<Owner>> queryOwners() {
+	public Function<OwnerQueryRequest, List<OwnerDto>> queryOwners() {
 		return name -> {
-			Pageable pageable = PageRequest.of(0, 10);
-			return owners.findByLastName(name.lastName, pageable).toList();
+			return ownerService.findByLastName(name.lastName);
 		};
 	}
 
 	@Bean
 	@Description("Create a new owner by providing the owner's firstName, lastName, address, telephone and city")
-	public Function<OwnerCURequest, Owner> addOwner() {
+	public Function<OwnerCURequest, OwnerDto> addOwner() {
 		return request -> {
-			Owner owner = new Owner();
+			OwnerDto owner = new OwnerDto();
 			owner.setAddress(request.address);
 			owner.setTelephone(request.telephone);
 			owner.setCity(request.city);
 			owner.setLastName(request.lastName);
 			owner.setFirstName(request.firstName);
-			this.owners.save(owner);
+			ownerService.save(owner);
 			return owner;
 		};
 	}
 
 	@Bean
 	@Description("update a owner's firstName, lastName, address, telephone and city by providing the owner id\"")
-	public Function<OwnerCURequest, Owner> updateOwner() {
+	public Function<OwnerCURequest, OwnerDto> updateOwner() {
 		return request -> {
-			Owner owner = owners.findById(Integer.parseInt(request.ownerId));
+			OwnerDto owner = ownerService.findById(Integer.parseInt(request.ownerId));
 			if (request.address != null) {
 				owner.setAddress(request.address);
 			}
@@ -70,7 +67,7 @@ public class OwnerTools {
 			if (request.firstName != null) {
 				owner.setFirstName(request.firstName);
 			}
-			this.owners.save(owner);
+			ownerService.save(owner);
 			return owner;
 		};
 	}

--- a/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/chat/OwnerTools.java
+++ b/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/chat/OwnerTools.java
@@ -23,12 +23,12 @@ public class OwnerTools {
 	}
 
 	@Bean
-	@Description("Query the owners by last name, the owner information include owner id, address, telephone, city, first name and last name"
+	@Description("Query the owners by first name, the owner information include owner id, address, telephone, city, first name and last name"
 			+ "\n The owner also include the pets information, include the pet name, pet type and birth"
-			+ "\n The pet include serveral visit record, include the visit name and visit date")
+			+ "\n The pet include several visit records, include the visit name and visit date")
 	public Function<OwnerQueryRequest, List<OwnerDto>> queryOwners() {
 		return name -> {
-			return ownerService.findByLastName(name.lastName);
+			return ownerService.findByFirstName(name.firstName);
 		};
 	}
 
@@ -75,7 +75,7 @@ public class OwnerTools {
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	@JsonClassDescription("Owner Query Request")
 	public record OwnerQueryRequest(@JsonProperty(required = false,
-			value = "lastName") @JsonPropertyDescription("The Owner last name") String lastName) {
+			value = "firstName") @JsonPropertyDescription("The Owner first name") String firstName) {
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/chat/VetTools.java
+++ b/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/chat/VetTools.java
@@ -7,8 +7,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Description;
-import org.springframework.samples.petclinic.agent.vet.Vet;
-import org.springframework.samples.petclinic.agent.vet.VetRepository;
+import org.springframework.samples.petclinic.agent.dto.VetDto;
+import org.springframework.samples.petclinic.agent.service.VetService;
 
 import java.util.Collection;
 import java.util.function.Function;
@@ -16,17 +16,17 @@ import java.util.function.Function;
 @Configuration
 public class VetTools {
 
-	private final VetRepository vetRepository;
+	private final VetService vetService;
 
-	public VetTools(VetRepository vetRepository) {
-		this.vetRepository = vetRepository;
+	public VetTools(VetService vetService) {
+		this.vetService = vetService;
 	}
 
 	@Bean
 	@Description("return list of Vets, include their specialties")
-	public Function<Request, Collection<Vet>> queryVets() {
+	public Function<Request, Collection<VetDto>> queryVets() {
 		return request -> {
-			return vetRepository.findAll();
+			return vetService.findAll();
 		};
 	}
 

--- a/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/dto/OwnerDto.java
+++ b/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/dto/OwnerDto.java
@@ -1,0 +1,23 @@
+package org.springframework.samples.petclinic.agent.dto;
+
+import lombok.Data;
+
+import java.util.Set;
+
+@Data
+public class OwnerDto {
+
+    private Integer id;
+
+    private String firstName;
+
+    private String lastName;
+
+    private String address;
+
+    private String city;
+
+    private String telephone;
+
+    private Set<PetDto> pets;
+}

--- a/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/dto/PetDto.java
+++ b/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/dto/PetDto.java
@@ -1,0 +1,19 @@
+package org.springframework.samples.petclinic.agent.dto;
+
+import lombok.Data;
+
+import java.util.Date;
+
+@Data
+public class PetDto {
+
+    private Integer id;
+
+    private String name;
+
+    private Date birthDate;
+
+    private PetTypeDto type;
+
+    private OwnerDto owner;
+}

--- a/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/dto/PetTypeDto.java
+++ b/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/dto/PetTypeDto.java
@@ -1,0 +1,12 @@
+package org.springframework.samples.petclinic.agent.dto;
+
+import lombok.Data;
+
+@Data
+public class PetTypeDto {
+
+    private Integer id;
+
+    private String name;
+
+}

--- a/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/dto/SpecialtyDto.java
+++ b/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/dto/SpecialtyDto.java
@@ -1,0 +1,12 @@
+package org.springframework.samples.petclinic.agent.dto;
+
+import lombok.Data;
+
+@Data
+public class SpecialtyDto {
+
+    private Integer id;
+
+    private String name;
+
+}

--- a/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/dto/VetDto.java
+++ b/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/dto/VetDto.java
@@ -1,0 +1,18 @@
+package org.springframework.samples.petclinic.agent.dto;
+
+import lombok.Data;
+
+import java.util.Set;
+
+@Data
+public class VetDto {
+
+    private Integer id;
+
+    private String firstName;
+
+    private String lastName;
+
+    private Set<SpecialtyDto> specialties;
+
+}

--- a/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/service/OwnerService.java
+++ b/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/service/OwnerService.java
@@ -5,6 +5,7 @@ import org.springframework.samples.petclinic.agent.dto.OwnerDto;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -17,10 +18,13 @@ public class OwnerService {
         this.restTemplate = restTemplate;
     }
 
-    public List<OwnerDto> findByLastName(String lastName) {
-        var owners = restTemplate.getForObject("http://customers-service/owners/lastname/{lastName}", OwnerDto[].class, lastName);
-        assert owners != null;
-        return List.of(owners);
+    public List<OwnerDto> findByFirstName(String firstName) {
+        var owners = restTemplate.getForObject("http://customers-service/owners/firstname/{firstName}", OwnerDto[].class, firstName);
+        if (owners != null) {
+            return List.of(owners);
+        } else {
+            return new ArrayList<>();
+        }
     }
 
     public OwnerDto findById(int ownerId) {

--- a/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/service/OwnerService.java
+++ b/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/service/OwnerService.java
@@ -1,0 +1,33 @@
+package org.springframework.samples.petclinic.agent.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.samples.petclinic.agent.dto.OwnerDto;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+@Service
+public class OwnerService {
+
+    private final RestTemplate restTemplate;
+
+    @Autowired
+    public OwnerService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    public List<OwnerDto> findByLastName(String lastName) {
+        var owners = restTemplate.getForObject("http://customers-service/owners/lastname/{lastName}", OwnerDto[].class, lastName);
+        assert owners != null;
+        return List.of(owners);
+    }
+
+    public OwnerDto findById(int ownerId) {
+        return restTemplate.getForObject("http://customers-service/owners/{ownerId}", OwnerDto.class, ownerId);
+    }
+
+    public void save(OwnerDto owner) {
+        restTemplate.postForEntity("http://customers-service/owners", owner, OwnerDto.class);
+    }
+}

--- a/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/service/VetService.java
+++ b/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/service/VetService.java
@@ -1,0 +1,26 @@
+package org.springframework.samples.petclinic.agent.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.samples.petclinic.agent.dto.VetDto;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+@Service
+public class VetService {
+
+    private final RestTemplate restTemplate;
+
+    @Autowired
+    public VetService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    public List<VetDto> findAll() {
+        var vets = restTemplate.getForObject("http://vets-service/vets", VetDto[].class);
+        assert vets != null;
+        return List.of(vets);
+    }
+
+}

--- a/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/service/VetService.java
+++ b/src/spring-petclinic-chat-agent/src/main/java/org/springframework/samples/petclinic/agent/service/VetService.java
@@ -5,6 +5,7 @@ import org.springframework.samples.petclinic.agent.dto.VetDto;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -19,8 +20,11 @@ public class VetService {
 
     public List<VetDto> findAll() {
         var vets = restTemplate.getForObject("http://vets-service/vets", VetDto[].class);
-        assert vets != null;
-        return List.of(vets);
+        if (vets != null) {
+            return List.of(vets);
+        } else {
+            return new ArrayList<>();
+        }
     }
 
 }

--- a/src/spring-petclinic-chat-agent/src/main/resources/application.yml
+++ b/src/spring-petclinic-chat-agent/src/main/resources/application.yml
@@ -41,7 +41,7 @@ spring:
         client-id: <your-managed-identity-client-id>
         chat:
           options:
-            deployment-name: gpt-4
+            deployment-name: gpt-4o
             temperature: 0.8
         embedding:
           options:

--- a/src/spring-petclinic-chat-agent/src/main/resources/application.yml
+++ b/src/spring-petclinic-chat-agent/src/main/resources/application.yml
@@ -41,7 +41,7 @@ spring:
         client-id: ${CLIENT_ID}
         chat:
           options:
-            deployment-name: gpt-4o
+            deployment-name: gpt-4
             temperature: 0.8
         embedding:
           options:

--- a/src/spring-petclinic-chat-agent/src/main/resources/application.yml
+++ b/src/spring-petclinic-chat-agent/src/main/resources/application.yml
@@ -37,8 +37,8 @@ spring:
   ai:
     azure:
       openai:
-        endpoint: ${AZURE_OPENAI_ENDPOINT}
-        client-id: ${CLIENT_ID}
+        endpoint: <your-azure-open-ai-endpoint>
+        client-id: <your-managed-identity-client-id>
         chat:
           options:
             deployment-name: gpt-4

--- a/src/spring-petclinic-chat-agent/src/main/resources/application.yml
+++ b/src/spring-petclinic-chat-agent/src/main/resources/application.yml
@@ -41,7 +41,7 @@ spring:
         client-id: ${CLIENT_ID}
         chat:
           options:
-            deployment-name: gpt-4
+            deployment-name: gpt-4o
             temperature: 0.8
         embedding:
           options:

--- a/src/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/model/OwnerRepository.java
+++ b/src/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/model/OwnerRepository.java
@@ -16,6 +16,10 @@
 package org.springframework.samples.petclinic.customers.model;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 /**
  * Repository class for <code>Owner</code> domain objects All method names are compliant with Spring Data naming
@@ -27,4 +31,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * @author Michael Isvy
  * @author Maciej Szarlinski
  */
-public interface OwnerRepository extends JpaRepository<Owner, Integer> { }
+public interface OwnerRepository extends JpaRepository<Owner, Integer> {
+
+    @Query("SELECT o FROM Owner o WHERE LOWER(o.lastName) = LOWER(:lastName)")
+    List<Owner> findByLastName(@Param("lastName") String lastName);
+}

--- a/src/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/model/OwnerRepository.java
+++ b/src/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/model/OwnerRepository.java
@@ -33,6 +33,6 @@ import java.util.List;
  */
 public interface OwnerRepository extends JpaRepository<Owner, Integer> {
 
-    @Query("SELECT o FROM Owner o WHERE LOWER(o.lastName) = LOWER(:lastName)")
-    List<Owner> findByLastName(@Param("lastName") String lastName);
+    @Query("SELECT o FROM Owner o WHERE LOWER(o.firstName) = LOWER(:firstName)")
+    List<Owner> findByFirstName(@Param("firstName") String firstName);
 }

--- a/src/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/OwnerResource.java
+++ b/src/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/OwnerResource.java
@@ -65,7 +65,7 @@ class OwnerResource {
      * Find owners by first name
      */
     @GetMapping(value = "/firstname/{firstName}")
-    public List<Owner> findOwnersByLastName(@PathVariable("firstName") String firstName) {
+    public List<Owner> findOwnersByFirstName(@PathVariable("firstName") String firstName) {
         return ownerRepository.findByFirstName(firstName);
     }
 

--- a/src/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/OwnerResource.java
+++ b/src/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/OwnerResource.java
@@ -62,6 +62,14 @@ class OwnerResource {
     }
 
     /**
+     * Find owners by last name
+     */
+    @GetMapping(value = "/lastname/{lastName}")
+    public List<Owner> findOwnersByLastName(@PathVariable("lastName") String lastName) {
+        return ownerRepository.findByLastName(lastName);
+    }
+
+    /**
      * Read List of Owners
      */
     @GetMapping

--- a/src/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/OwnerResource.java
+++ b/src/spring-petclinic-customers-service/src/main/java/org/springframework/samples/petclinic/customers/web/OwnerResource.java
@@ -62,11 +62,11 @@ class OwnerResource {
     }
 
     /**
-     * Find owners by last name
+     * Find owners by first name
      */
-    @GetMapping(value = "/lastname/{lastName}")
-    public List<Owner> findOwnersByLastName(@PathVariable("lastName") String lastName) {
-        return ownerRepository.findByLastName(lastName);
+    @GetMapping(value = "/firstname/{firstName}")
+    public List<Owner> findOwnersByLastName(@PathVariable("firstName") String firstName) {
+        return ownerRepository.findByFirstName(firstName);
     }
 
     /**


### PR DESCRIPTION
## Purpose

Make chat agent use the same online MySQL database as other components.
Currently the local DB config still exists, because some UI is using it. Will update the UI later and then we can simplify.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->